### PR TITLE
Allow larger broadcast messages

### DIFF
--- a/node/src/transport.spec.mjs
+++ b/node/src/transport.spec.mjs
@@ -41,4 +41,7 @@ describe('EurekaServer', () => {
       instance2.closeServer()
     }
   })
+  it('should fragment and reassemble messages larger than MTU', async () => {
+    fail('not implemented')
+  })
 })


### PR DESCRIPTION
It would be nice if the state description could be transmitted in one message even when larger than 1500. The transport class will need to handle this for protocols that do not have it builtin.